### PR TITLE
Remove hardcoded 'Aemony' username in target output directory

### DIFF
--- a/SKIFsvc.vcxproj
+++ b/SKIFsvc.vcxproj
@@ -47,13 +47,13 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>F:\Aemony\Documents\My Mods\SpecialK\Servlet\</OutDir>
+    <OutDir>%USERPROFILE%\Documents\My Mods\SpecialK\Servlet\</OutDir>
     <TargetName>SKIFsvc32</TargetName>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>F:\Aemony\Documents\My Mods\SpecialK\Servlet\</OutDir>
+    <OutDir>%USERPROFILE%\Documents\My Mods\SpecialK\Servlet\</OutDir>
     <TargetName>SKIFsvc64</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
Substitute %USERPROFILE% instead so that people with usernames other than
'Aemony' can build the project without having to modify the build files.